### PR TITLE
Fixed --prod for font-awesome and angular

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -156,14 +156,14 @@ module.exports = function (grunt) {
         ]
       },
       prod : {
-		  files : [
-          	{
-              expand: true,
-              cwd: './bower_components/font-awesome/fonts/',
-              src: ['**/*'],
-              dest: '.tmp/public/fonts'
-		  	}
-          ]
+	files : [
+          {
+            expand: true,
+            cwd: './bower_components/font-awesome/fonts/',
+            src: ['**/*'],
+            dest: '.tmp/public/fonts'
+          }
+        ]
       },
       build: {
         files: [


### PR DESCRIPTION
fixes font-awesome fonts path being incorrect on with asset minification, as well as turning off mangle so that angular.js dependency injections work correctly.
